### PR TITLE
Race Condition Adding Metrics

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -28,6 +28,9 @@ type NewrelicPlugin struct {
 	// to use a proxy.
 	Client http.Client `json:"-"`
 
+	// The URL to use for New Relic. Can change for testing purposes. Defaults to NERELIC_API_URL
+	URL string
+
 	ComponentModels      []IComponent `json:"-"`
 	LastPollTime         time.Time    `json:"-"`
 	Verbose              bool         `json:"-"`
@@ -43,6 +46,7 @@ func NewNewrelicPlugin(version string, licenseKey string, pollInterval int) *New
 
 	plugin.Agent = NewAgent(version)
 	plugin.Agent.CollectEnvironmentInfo()
+	plugin.URL = NEWRELIC_API_URL
 
 	plugin.ComponentModels = []IComponent{}
 	return plugin
@@ -116,7 +120,7 @@ func (plugin *NewrelicPlugin) SendMetricas() (int, error) {
 		log.Printf("Send data:%s \n", jsonAsString)
 	}
 
-	if httpRequest, err := http.NewRequest("POST", NEWRELIC_API_URL, strings.NewReader(jsonAsString)); err != nil {
+	if httpRequest, err := http.NewRequest("POST", plugin.URL, strings.NewReader(jsonAsString)); err != nil {
 		return 0, err
 	} else {
 		httpRequest.Header.Set("X-License-Key", plugin.LicenseKey)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,0 +1,81 @@
+package newrelic_platform_go
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Mocks a Metrica object
+type MockMetrica struct {
+	Value float64
+	Name  string
+	Units string
+}
+
+// Gets a default new mock metrica
+func NewMockMetrica() MockMetrica {
+	return MockMetrica{
+		Value: 5.2,
+		Name:  "mock-metrica",
+		Units: "flots",
+	}
+}
+
+func (m MockMetrica) GetValue() (float64, error) {
+	return m.Value, nil
+}
+func (m MockMetrica) GetName() string {
+	return m.Name
+}
+func (m MockMetrica) GetUnits() string {
+	return m.Units
+}
+
+// Struct representing a mock of New Relic
+type MockNewRelic struct {
+	RequestFunc http.HandlerFunc
+	Server      *httptest.Server
+}
+
+// Create a new mock for the New Relic service
+func NewMockNewRelic() MockNewRelic {
+	mock := MockNewRelic{}
+	mock.RequestFunc = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+	mock.Server = httptest.NewServer(mock.RequestFunc)
+
+	return mock
+}
+
+// Represents a new mock plugin for testing new relic
+type MockPlugin struct {
+	NewRelic MockNewRelic
+	Plugin   *NewrelicPlugin
+}
+
+// Create a new plugin to test with
+func NewMockPlugin() MockPlugin {
+	mockPlugin := MockPlugin{}
+	mockPlugin.Plugin = NewNewrelicPlugin("test.dev", "dummy-key", 1)
+	mockPlugin.NewRelic = NewMockNewRelic()
+	mockPlugin.Plugin.URL = mockPlugin.NewRelic.Server.URL
+	mockPlugin.Plugin.AddComponent(NewPluginComponent("foo-component", "foo-guid", true))
+	return mockPlugin
+}
+
+// Tests that a race condition doesn't occur when adding metrics and harvesting
+func TestRaceCondition(t *testing.T) {
+	mockPlugin := NewMockPlugin()
+	go mockPlugin.Plugin.Run()
+
+	start := time.Now().Unix()
+	for ts := range time.Tick(10 * time.Millisecond) {
+		if start+10 < ts.Unix() {
+			break
+		}
+		mockPlugin.Plugin.ComponentModels[0].AddMetrica(NewMockMetrica())
+	}
+}

--- a/tags
+++ b/tags
@@ -1,6 +1,0 @@
-!_TAG_FILE_FORMAT	2
-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted/
-!_TAG_PROGRAM_AUTHOR	Joel Stemmer	/stemmertech@gmail.com/
-!_TAG_PROGRAM_NAME	gotags
-!_TAG_PROGRAM_URL	https://github.com/jstemmer/gotags
-!_TAG_PROGRAM_VERSION	1.3.0	/go1.5.3/

--- a/tags
+++ b/tags
@@ -1,0 +1,6 @@
+!_TAG_FILE_FORMAT	2
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted/
+!_TAG_PROGRAM_AUTHOR	Joel Stemmer	/stemmertech@gmail.com/
+!_TAG_PROGRAM_NAME	gotags
+!_TAG_PROGRAM_URL	https://github.com/jstemmer/gotags
+!_TAG_PROGRAM_VERSION	1.3.0	/go1.5.3/


### PR DESCRIPTION
@yvasiyarov 

I was testing this out with my application when I found a race condition.  My application has a large integration testing suite so I decided to test this library by utilizing that.  During that process, I hit a race condition with one of my modules.

After some investigation, it was determined that the race condition was caused by the [Tracer struct adding metrica](https://github.com/yvasiyarov/gorelic/blob/62638bfdaebd09d74b8b07366c23bdc5654866ca/tracer_metrics.go#L49).

I've added some tests that show this race condition as well.  If you remove the code I've updated in `component.go` and run the tests using `go test -race`, you'll see the race condition occur.

A little background:

I'm using [gocraft-web](https://github.com/gocraft/web) and I used a version of the middleware for that adapted from [your other repository](https://github.com/yvasiyarov/gocraft_gorelic/blob/master/gorelic.go#L13).

Here is the updated code:

```
func NewRelicMiddleware(rw web.ResponseWriter, r *web.Request, next web.NextMiddlewareFunc) {
    startTime := time.Now()
    newrelic.Agent.Tracer.Trace(r.Method+" - "+r.URL.Path, func() {
        next(rw, r)
    })
    newrelic.Agent.HTTPTimer.UpdateSince(startTime)
}
```

You can see here, I'm attempting to use the tracer on my request stack.  I also wanted to ask you if this makes sense in the context of your library, or if you think that's overkill.
